### PR TITLE
Update group.vue, EmojiCardGroup labels, select-none

### DIFF
--- a/components/emoji/card/group.vue
+++ b/components/emoji/card/group.vue
@@ -39,7 +39,7 @@ async function setGroup(group: EmojiGroupKey) {
       :name="props.group.icon"
       class="text-2xl group-hover:scale-110 transition-transform"
     />
-    <p class="text-xs font-medium text-zinc-700 dark:text-zinc-200">
+    <p class="text-xs font-medium text-zinc-700 dark:text-zinc-200 select-none">
       {{ props.group.key }}
     </p>
   </div>


### PR DESCRIPTION
Added "select-none" class to prevent text selection

<img width="1033" alt="Screenshot 2025-04-28 at 12 27 31" src="https://github.com/user-attachments/assets/53806f91-ba3c-4b57-9e1d-28a651be63cd" />
